### PR TITLE
Add mathjax compatibility

### DIFF
--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -26,9 +26,13 @@
 	<script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
 	<![endif]-->
 
+  <!-- Math rendering scripts -->
+  <script src='https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.5/MathJax.js?config=TeX-MML-AM_CHTML' async></script>
+  <script type="text/x-mathjax-config"> MathJax.Hub.Config({ tex2jax: { inlineMath: [ ['$','$'], ["\\(","\\)"] ], processEscapes: true } }); </script> <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"> </script>
+
   <title>
   {% if page.title %}{{ page.title }}{% endif %}{% if page.title and site.title %} &ndash; {% endif %}{% if site.title %}{{ site.title }}{% endif %}
-  </title>  
+  </title>
 
   </head>
   <body>


### PR DESCRIPTION
I couldn't find any guidelines about math typesetting in escience-academy documents.

With this (perhaps hacky) addition, dollar signs can be used for inline math and double dollar signs for math blocks.

See [here](https://github.com/escience-academy/lesson-modelling/commit/ca52db9f21eb4fea2ddf39edffe0419d9fd1d2a2) an example of usage.