### PR TITLE
Fix some bugs in bin files

### DIFF
--- a/bin/lesson_check.py
+++ b/bin/lesson_check.py
@@ -177,7 +177,7 @@ def check_config(reporter, source_dir):
     reporter.check_field(config_file, 'configuration',
                          config, 'kind', 'lesson')
     reporter.check_field(config_file, 'configuration',
-                         config, 'carpentry', ('swc', 'dc', 'lc', 'cp'))
+                         config, 'carpentry', ('swc', 'dc', 'lc', 'cp', 'ea'))
     reporter.check_field(config_file, 'configuration', config, 'title')
     reporter.check_field(config_file, 'configuration', config, 'email')
 

--- a/bin/repo_check.py
+++ b/bin/repo_check.py
@@ -20,7 +20,7 @@ except ImportError:
 
 
 # Pattern to match Git command-line output for remotes => (user name, project name).
-P_GIT_REMOTE = re.compile(r'upstream\s+[^:]+:([^/]+)/([^.]+)\.git\s+\(fetch\)')
+P_GIT_REMOTE = re.compile(r'origin\s+[^:]+:([^/]+)/([^.]+)\.git\s+\(fetch\)')
 
 # Repository URL format string.
 F_REPO_URL = 'https://github.com/{0}/{1}/'


### PR DESCRIPTION
1. add `ea` to `/bin/lesson_check.py` to make sure `make lesson-check` works well.
2. `git remote -v` outputs e.g. `origin git@github.com:escience-academy/lesson_ML.git (fetch)` but not 
`upstream git@github.com:escience-academy/lesson_ML.git (fetch)`. So the `re` should match `origin` but not `upstream`.